### PR TITLE
go-annotate script

### DIFF
--- a/scripts/go-annotate
+++ b/scripts/go-annotate
@@ -1,0 +1,37 @@
+#!/bin/bash
+# This is a script that runs go build with the `-m` gcflag (which outputs
+# details about escape analysis and inlining choices) and annotates the source
+# files in the current directory with the resulting messages. The annotated
+# files are put into ./annotated/
+
+set -e
+
+mkdir -p annotated
+
+BLDOUT=`mktemp`
+trap "rm -f $BLDOUT" EXIT
+
+SEDSCRIPT=`mktemp`
+trap "rm -f $SEDSCRIPT" EXIT
+
+go build -gcflags='-m' >$BLDOUT 2>&1
+
+# Sample output of command above:
+#   # github.com/RaduBerinde/playground/escape-test
+#   /go/src/github.com/RaduBerinde/playground/escape-test/main.go:7: can inline cucu.func1
+#   /go/src/github.com/RaduBerinde/playground/escape-test/main.go:7: func literal escapes to heap
+#
+# We convert each line to a sed expression that appends the message as a comment.
+
+for FILE in *.go; do
+  # The following command converts lines from:
+  #   /go/src/github.com/RaduBerinde/playground/escape-test/main.go:7: can inline cucu.func1
+  # to
+  #   '7 s#$#  // can inline cucu.func1#'
+  #
+  # Note that s#x#y# and s|x|y| are both equivalent to s/x/y/ (any character
+  # can be used); they help avoid using escapes.
+  grep "$FILE:" $BLDOUT | sed 's|^.*'$FILE':\([0-9]*\): \(.*$\)|\1 s#$#  //
+  \2#|' >$SEDSCRIPT
+  sed -f $SEDSCRIPT $FILE >annotated/$FILE
+done


### PR DESCRIPTION
Adding a script that annotates source code files with the output of goescape.
Each thing returned by go build is appended to the correct line as a comment.

Sample output:

```
        y := struct{}{}  // moved to heap: y
        x := &y  // y escapes to heap
        TestFunc(x)  // x escapes to heap
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/go-lab/1)

<!-- Reviewable:end -->
